### PR TITLE
Publish prereleases through the default npm tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
         run: pnpm run test:package
 
       - name: Publish package
-        run: npm publish ./apps/cli --access public
+        run: npm publish ./apps/cli --access public --tag latest
 
       - name: Verify npm dist-tags
         run: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -70,6 +70,7 @@ jobs:
           assert.equal(cli.version, expectedVersion);
           assert.match(cli.version, /^\d+\.\d+\.\d+-alpha\.\d+$/);
           assert.equal(cli.publishConfig?.access, 'public');
+          assert.equal(cli.publishConfig?.tag, 'latest');
           if (isTagPush) {
             assert.equal(process.env.GITHUB_REF_NAME, `v${cli.version}`);
             assert.equal(

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -211,6 +211,7 @@
   },
   "license": "Apache-2.0",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   }
 }

--- a/scripts/test-package-install.mjs
+++ b/scripts/test-package-install.mjs
@@ -100,6 +100,10 @@ function assertExpectedPublicPath(path) {
 async function main() {
   const packageManifest = await readJson(join(cliDir, 'package.json'));
   assert.equal(packageManifest.name, packageName);
+  assert.deepEqual(packageManifest.publishConfig, {
+    access: 'public',
+    tag: 'latest',
+  });
   const packageVersion = packageManifest.version;
   const sourcePokefetchManifest = await readJson(
     join(cliDir, 'src/ui/components/layout/resources/pokemon/manifest.json'),


### PR DESCRIPTION
## Summary

- explicitly publish prerelease packages with `--tag latest` because current npm rejects prerelease publication without a dist-tag
- declare `publishConfig.tag` as `latest` in the public package so the default install channel is durable package metadata, not only CI behavior
- enforce that declaration in package smoke and release identity checks

This intentionally preserves `npm install --global @deepseek-ai/dsh @cofy-x/dsh-console`; it does not introduce an `alpha` install suffix.

## Verification

- workflow YAML parses successfully
- `pnpm run format:check`
- `pnpm run test:package`
- the existing release workflow verifies `dist-tags.latest` equals the package version
- the immutable `v0.1.0-alpha.7` tag and its Release Check remain valid; after this fix merges, the original tag event will be retriggered without moving the tag