### PR TITLE
Support DeepSeek Harness 0.1.2-alpha.2

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: deepseek-ai/DeepSeek-Harness
-          ref: cd5ef8148158c3a752a658978873241fdf8e2bbc
+          ref: 0a53fb55bea101816fa226bb964ae2bed71c343b
           path: _dsh-source
           fetch-depth: 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.0-alpha.8] - 2026-08-31
+
+### Changed
+
+- Verify the Console host through DeepSeek Harness `0.1.2-alpha.2`, including its Session event compatibility, projection ownership, and runtime dependency changes.
+
 ## [0.1.0-alpha.7] - 2026-08-30
 
 ### Changed
@@ -97,7 +103,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Keep debug diagnostics aligned within the existing footer row and preserve structured logs in the debug console.
 - Address initial CodeQL findings, dependency advisories, CI concurrency issues, and release build ordering.
 
-[Unreleased]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.7...HEAD
+[Unreleased]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.8...HEAD
+[0.1.0-alpha.8]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.7...v0.1.0-alpha.8
 [0.1.0-alpha.7]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.6...v0.1.0-alpha.7
 [0.1.0-alpha.6]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.5...v0.1.0-alpha.6
 [0.1.0-alpha.5]: https://github.com/cofy-x/dsh-console/compare/v0.1.0-alpha.4...v0.1.0-alpha.5

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dsh-console
 
 The `dsh-console` launcher initializes or locates its DSH profile, then starts the interactive TUI.
 
-This Console release is verified from the npm-default DSH `0.1.1-rc.2` through the current source release `0.1.2-alpha.1`. The upper bound advances only after each new DSH release passes an API audit and integration tests; users do not need to pin DSH in the install command.
+This Console release is verified from the npm-default DSH `0.1.1-rc.2` through the current source release `0.1.2-alpha.2`. The upper bound advances only after each new DSH release passes an API audit and integration tests; users do not need to pin DSH in the install command.
 
 Start directly with a prompt:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -21,7 +21,7 @@ dsh-console
 
 `dsh-console` launcher 会初始化或定位对应的 DSH profile，然后启动交互式 TUI。
 
-此 Console 版本已验证从 npm 默认的 DSH `0.1.1-rc.2` 到当前源码 release `0.1.2-alpha.1`。每次 DSH 发布后，只有完成 API 审计和集成验证才会提升兼容上界；用户无需在安装命令中固定 DSH 版本。
+此 Console 版本已验证从 npm 默认的 DSH `0.1.1-rc.2` 到当前源码 release `0.1.2-alpha.2`。每次 DSH 发布后，只有完成 API 审计和集成验证才会提升兼容上界；用户无需在安装命令中固定 DSH 版本。
 
 也可以直接带 Prompt 启动：
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-DSH Console requires Node.js 24 or newer and a working DSH provider configuration. This release is verified from the npm-default DeepSeek Harness `0.1.1-rc.2` through the current source release `0.1.2-alpha.1`; install DSH normally without pinning the command to a version.
+DSH Console requires Node.js 24 or newer and a working DSH provider configuration. This release is verified from the npm-default DeepSeek Harness `0.1.1-rc.2` through the current source release `0.1.2-alpha.2`; install DSH normally without pinning the command to a version.
 
 ```sh
 npm install --global @deepseek-ai/dsh @cofy-x/dsh-console

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cofy-x/dsh-console",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "A TypeScript and React/Ink terminal frontend for DeepSeek Harness.",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     },
     "compatibility": {
       "minimum": "0.1.1-rc.2",
-      "maximumTested": "0.1.2-alpha.1"
+      "maximumTested": "0.1.2-alpha.2"
     }
   },
   "dependencies": {
@@ -128,23 +128,23 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.1-rc.1 <5.0.0",
     "@deepseek-ai/cordis-plugin-loader": ">=1.0.2 <2.0.0",
-    "@deepseek-ai/dsh-cmdline": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-agent": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-agent-default-model": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-attachment": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-commands": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-credentials": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-llm": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-permission-presets": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-session": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-session-projection": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-session-query": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-settings": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-subagent": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-tool-todo": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-tools": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-user-approval": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
-    "@deepseek-ai/dsh-user-questions": ">=0.1.1-rc.2 <=0.1.2-alpha.1",
+    "@deepseek-ai/dsh-cmdline": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-agent": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-agent-default-model": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-attachment": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-commands": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-credentials": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-llm": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-permission-presets": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-session": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-session-projection": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-session-query": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-settings": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-subagent": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-tool-todo": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-tools": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-user-approval": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
+    "@deepseek-ai/dsh-user-questions": ">=0.1.1-rc.2 <=0.1.2-alpha.2",
     "@deepseek-ai/schemastery": ">=3.18.1 <4.0.0"
   },
   "peerDependenciesMeta": {

--- a/apps/docs/src/content/docs/getting-started/index.md
+++ b/apps/docs/src/content/docs/getting-started/index.md
@@ -12,7 +12,7 @@ dsh-console
 
 The launcher initializes or locates the `dsh-console` DSH profile and opens the interactive TUI. If the selected DeepSeek provider has no credential, the Console opens a masked setup dialog before it submits the first prompt.
 
-This release is verified from the npm-default DSH `0.1.1-rc.2` through the current source release `0.1.2-alpha.1`. Its declared upper compatibility bound advances only after a new DSH release passes API audit and integration tests; the install command itself stays unpinned.
+This release is verified from the npm-default DSH `0.1.1-rc.2` through the current source release `0.1.2-alpha.2`. Its declared upper compatibility bound advances only after a new DSH release passes API audit and integration tests; the install command itself stays unpinned.
 
 You can also start with a prompt:
 

--- a/apps/docs/src/content/docs/zh-cn/getting-started/index.md
+++ b/apps/docs/src/content/docs/zh-cn/getting-started/index.md
@@ -12,7 +12,7 @@ dsh-console
 
 Launcher 会初始化或定位 `dsh-console` DSH profile，并打开交互式 TUI。如果选中的 DeepSeek provider 尚未配置 credential，Console 会在提交第一个 Prompt 之前打开 masked setup dialog。
 
-此版本已验证从 npm 默认的 DSH `0.1.1-rc.2` 到当前源码 release `0.1.2-alpha.1`。只有新 DSH release 通过 API 审计和集成测试后才会提升声明的兼容上界；安装命令本身保持不固定版本。
+此版本已验证从 npm 默认的 DSH `0.1.1-rc.2` 到当前源码 release `0.1.2-alpha.2`。只有新 DSH release 通过 API 审计和集成测试后才会提升声明的兼容上界；安装命令本身保持不固定版本。
 
 也可以直接带 Prompt 启动：
 

--- a/scripts/test-dsh-integration.mjs
+++ b/scripts/test-dsh-integration.mjs
@@ -63,7 +63,7 @@ async function main() {
   assert.equal(cliManifest.name, '@cofy-x/dsh-console');
   assert.deepEqual(cliManifest.dsh.compatibility, {
     minimum: '0.1.1-rc.2',
-    maximumTested: '0.1.2-alpha.1',
+    maximumTested: '0.1.2-alpha.2',
   });
   assert.ok(
     [


### PR DESCRIPTION
## Product changes
- advance the audited DSH compatibility ceiling to 0.1.2-alpha.2
- verify Session event compatibility, projection ownership, and runtime dependency changes
- keep the default unpinned DSH installation path and the npm-default rc.2 baseline
- prepare the next Console prerelease as 0.1.0-alpha.8

## Validation
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run build:cli
- pnpm run test:ci (199 CLI files / 2247 tests; 19 core files / 348 tests)
- pnpm run test:integration:dsh against DSH source 0a53fb55bea101816fa226bb964ae2bed71c343b
- pnpm run test:package

## Risk
The npm-default DSH baseline remains 0.1.1-rc.2. The alpha.2 ceiling is enforced and continuously tested from the exact release source commit; no internal DSH implementation is pinned into the Console runtime.